### PR TITLE
Fixed bug that caused lgw_time_on_air to always return 0

### DIFF
--- a/src/SX1308HAL/src/loragw_hal.cpp
+++ b/src/SX1308HAL/src/loragw_hal.cpp
@@ -1484,7 +1484,7 @@ uint32_t lgw_time_on_air(struct lgw_pkt_tx_s *packet) {
         }
 
         /* Duration of 1 symbol */
-        Tsym = (2 ^ SF) / BW;
+        Tsym = pow(2.0, (int)SF) / BW;
 
         /* Duration of preamble */
         Tpreamble = (8 + 4.25) * Tsym; /* 8 programmed symbols in preamble */


### PR DESCRIPTION
It appears the original author mistakenly used the ^ symbol for exponentation, not realising that it represents bitwise XOR.