### PR TITLE
Enable GCC Toolchain support (Compiles and works in USB mode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/bin/*.o
+/bin/*.d
+/bin/lgw_fw_usb*
+/.ninja_deps
+/.ninja_log
+

--- a/build.ninja
+++ b/build.ninja
@@ -1,0 +1,446 @@
+# Used compiler:
+#   url: https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2
+#   md5sum: 13747255194398ee08b3ba42e40e9465
+# Used hex2dfu tool:
+#   url: https://github.com/plietar/dfuse-tool
+#   commit: e2b1c1c7f743f8f15a2d988476567470e3422aaa
+
+# Toolchain
+cc = arm-none-eabi-gcc
+cpp = arm-none-eabi-cpp
+cxx = arm-none-eabi-g++ -fpermissive
+ld = arm-none-eabi-gcc
+
+objs = $
+  bin/analogin.o $
+  bin/analogin_api.o $
+  bin/analogout_api.o $
+  bin/board.o $
+  bin/busin.o $
+  bin/businout.o $
+  bin/busout.o $
+  bin/callchain.o $
+  bin/can.o $
+  bin/can_api.o $
+  bin/cmdusb.o $
+  bin/cmsis_nvic.o $
+  bin/entropy_hardware_poll.o $
+  bin/ethernet.o $
+  bin/filebase.o $
+  bin/filelike.o $
+  bin/filepath.o $
+  bin/filesystemlike.o $
+  bin/gpio_api.o $
+  bin/gpio_irq_api.o $
+  bin/hal_tick.o $
+  bin/i2c.o $
+  bin/i2c_api.o $
+  bin/i2cslave.o $
+  bin/interruptin.o $
+  bin/interruptmanager.o $
+  bin/localfilesystem.o $
+  bin/loragw_hal.o $
+  bin/loragw_reg.o $
+  bin/main.o $
+  bin/mbed_alloc_wrappers.o $
+  bin/mbed_assert.o $
+  bin/mbed_board.o $
+  bin/mbed_critical.o $
+  bin/mbed_error.o $
+  bin/mbed_gpio.o $
+  bin/mbed_interface.o $
+  bin/mbed_lp_ticker_api.o $
+  bin/mbed_mem_trace.o $
+  bin/mbed_overrides.o $
+  bin/mbed_pinmap_common.o $
+  bin/mbed_rtc_time.o $
+  bin/mbed_semihost_api.o $
+  bin/mbed_ticker_api.o $
+  bin/mbed_us_ticker_api.o $
+  bin/mbed_wait_api.o $
+  bin/peripheralpins.o $
+  bin/pinmap.o $
+  bin/port_api.o $
+  bin/pwmout_api.o $
+  bin/rawserial.o $
+  bin/retarget.o $
+  bin/rtc_api.o $
+  bin/serial.o $
+  bin/serial_api.o $
+  bin/serialbase.o $
+  bin/sleep.o $
+  bin/spi.o $
+  bin/spi_api.o $
+  bin/spislave.o $
+  bin/startup_stm32f401xe.o $
+  bin/stm32f4xx_hal.o $
+  bin/stm32f4xx_hal_adc.o $
+  bin/stm32f4xx_hal_adc_ex.o $
+  bin/stm32f4xx_hal_can.o $
+  bin/stm32f4xx_hal_cec.o $
+  bin/stm32f4xx_hal_cortex.o $
+  bin/stm32f4xx_hal_crc.o $
+  bin/stm32f4xx_hal_cryp.o $
+  bin/stm32f4xx_hal_cryp_ex.o $
+  bin/stm32f4xx_hal_dac.o $
+  bin/stm32f4xx_hal_dac_ex.o $
+  bin/stm32f4xx_hal_dcmi.o $
+  bin/stm32f4xx_hal_dcmi_ex.o $
+  bin/stm32f4xx_hal_dfsdm.o $
+  bin/stm32f4xx_hal_dma.o $
+  bin/stm32f4xx_hal_dma2d.o $
+  bin/stm32f4xx_hal_dma_ex.o $
+  bin/stm32f4xx_hal_dsi.o $
+  bin/stm32f4xx_hal_eth.o $
+  bin/stm32f4xx_hal_flash.o $
+  bin/stm32f4xx_hal_flash_ex.o $
+  bin/stm32f4xx_hal_flash_ramfunc.o $
+  bin/stm32f4xx_hal_fmpi2c.o $
+  bin/stm32f4xx_hal_fmpi2c_ex.o $
+  bin/stm32f4xx_hal_gpio.o $
+  bin/stm32f4xx_hal_hash.o $
+  bin/stm32f4xx_hal_hash_ex.o $
+  bin/stm32f4xx_hal_hcd.o $
+  bin/stm32f4xx_hal_i2c.o $
+  bin/stm32f4xx_hal_i2c_ex.o $
+  bin/stm32f4xx_hal_i2s.o $
+  bin/stm32f4xx_hal_i2s_ex.o $
+  bin/stm32f4xx_hal_irda.o $
+  bin/stm32f4xx_hal_iwdg.o $
+  bin/stm32f4xx_hal_lptim.o $
+  bin/stm32f4xx_hal_ltdc.o $
+  bin/stm32f4xx_hal_ltdc_ex.o $
+  bin/stm32f4xx_hal_msp_template.o $
+  bin/stm32f4xx_hal_nand.o $
+  bin/stm32f4xx_hal_nor.o $
+  bin/stm32f4xx_hal_pccard.o $
+  bin/stm32f4xx_hal_pcd.o $
+  bin/stm32f4xx_hal_pcd_ex.o $
+  bin/stm32f4xx_hal_pwr.o $
+  bin/stm32f4xx_hal_pwr_ex.o $
+  bin/stm32f4xx_hal_qspi.o $
+  bin/stm32f4xx_hal_rcc.o $
+  bin/stm32f4xx_hal_rcc_ex.o $
+  bin/stm32f4xx_hal_rng.o $
+  bin/stm32f4xx_hal_rtc.o $
+  bin/stm32f4xx_hal_rtc_ex.o $
+  bin/stm32f4xx_hal_sai.o $
+  bin/stm32f4xx_hal_sai_ex.o $
+  bin/stm32f4xx_hal_sd.o $
+  bin/stm32f4xx_hal_sdram.o $
+  bin/stm32f4xx_hal_smartcard.o $
+  bin/stm32f4xx_hal_spdifrx.o $
+  bin/stm32f4xx_hal_spi.o $
+  bin/stm32f4xx_hal_sram.o $
+  bin/stm32f4xx_hal_tim.o $
+  bin/stm32f4xx_hal_tim_ex.o $
+  bin/stm32f4xx_hal_uart.o $
+  bin/stm32f4xx_hal_usart.o $
+  bin/stm32f4xx_hal_wwdg.o $
+  bin/stm32f4xx_it.o $
+  bin/stm32f4xx_ll_fmc.o $
+  bin/stm32f4xx_ll_fsmc.o $
+  bin/stm32f4xx_ll_sdmmc.o $
+  bin/stm32f4xx_ll_usb.o $
+  bin/stream.o $
+  bin/sx1308.o $
+  bin/system_stm32f4xx.o $
+  bin/ticker.o $
+  bin/timeout.o $
+  bin/timer.o $
+  bin/timerevent.o $
+  bin/us_ticker.o $
+  bin/usb_device.o $
+  bin/usbd_cdc.o $
+  bin/usbd_cdc_if.o $
+  bin/usbd_conf.o $
+  bin/usbd_core.o $
+  bin/usbd_ctlreq.o $
+  bin/usbd_desc.o $
+  bin/usbd_ioreq.o $
+
+imports = $
+  -I src/MAIN $
+  -I src/SX1308HAL/inc $
+  -I src/mbed-dev/api $
+  -I src/mbed-dev/common $
+  -I src/mbed-dev/hal $
+  -I src/mbed-dev/targets/cmsis $
+  -I src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4 $
+  -I src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE $
+  -I src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4 $
+  -I src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE $
+  -I src/usb_cdc/Inc $
+
+defines = $
+  -DARM_MATH_CM4 $
+  -DDEVICE_ANALOGIN=1 $
+  -DDEVICE_ERROR_RED=1 $
+  -DDEVICE_I2C=1 $
+  -DDEVICE_I2CSLAVE=1 $
+  -DDEVICE_INTERRUPTIN=1 $
+  -DDEVICE_PORTIN=1 $
+  -DDEVICE_PORTINOUT=1 $
+  -DDEVICE_PORTOUT=1 $
+  -DDEVICE_PWMOUT=1 $
+  -DDEVICE_RTC=1 $
+  -DDEVICE_SERIAL=1 $
+  -DDEVICE_SERIAL_ASYNCH=1 $
+  -DDEVICE_SERIAL_FC=1 $
+  -DDEVICE_SLEEP=1 $
+  -DDEVICE_SPI=1 $
+  -DDEVICE_SPISLAVE=1 $
+  -DDEVICE_STDIO_MESSAGES=1 $
+  -DSTM32F401xE $
+  -DTOOLCHAIN_GCC $
+  -DV2 $
+  -D__CORTEX_M4 $
+  -D__FPU_PRESENT=1 $
+
+cflags = $imports $defines $
+  -MMD $
+  -Os $
+  -fdata-sections $
+  -fdce $
+  -ffunction-sections $
+  -march=armv7e-m $
+  -mfloat-abi=hard $
+  -mfpu=fpv4-sp-d16 $
+  -mtune=cortex-m4 $
+  -s $
+  -w $
+
+cppflags = $
+  -Os $
+  -P $
+  -Wl,--gc-sections $
+  -Wl,--wrap,_calloc_r $
+  -Wl,--wrap,_free_r $
+  -Wl,--wrap,_malloc_r $
+  -Wl,--wrap,_memalign_r $
+  -Wl,--wrap,_realloc_r $
+  -Wl,--wrap,atexit $
+  -Wl,--wrap,exit $
+  -Wl,--wrap,main $
+  -Wl,-n $
+  -fdata-sections $
+  -fdce $
+  -ffunction-sections $
+  -mcpu=cortex-m4 $
+  -mfloat-abi=hard $
+  -mfpu=fpv4-sp-d16 $
+  -mthumb $
+  -s $
+
+ldflags = $
+  -Wl,--gc-sections $
+  -Wl,--wrap,_memalign_r $
+  -Wl,--wrap,main $
+  -Wl,-n $
+  -mcpu=cortex-m4 $
+  -mfloat-abi=hard $
+  -mfpu=fpv4-sp-d16 $
+  -mthumb $
+  -static $
+
+ldsyslibs = $
+  -Wl,--start-group $
+  -lstdc++ $
+  -lm $
+  -lc $
+  -lgcc $
+  -lnosys $
+  -Wl,--end-group $
+  -specs=nano.specs $
+
+asmflags = $
+  -MMD $
+  -march=armv7e-m $
+  -mfpu=fpv4-sp-d16 $
+  -mtune=cortex-m4 $
+
+allflags =
+#allflags = -Og -ggdb3
+
+rule asmcompile
+  command = $cc $asmflags -c $in -o $out $allflags
+
+rule compile
+  command = $cc $cflags -c $in -o $out $allflags
+
+rule cxxcompile
+  command = $cxx $cflags -fno-rtti -c $in -o $out $allflags
+
+rule preproc
+  command = $cpp $cppflags $in -o $out
+
+rule link
+  command = $ld --output $out $objs $ldflags -T bin/lgw_fw_usb.link_script.ld -Wl,-Map=bin/lgw_fw_usb.map $ldsyslibs $allflags
+
+rule elf2hex
+  command = arm-none-eabi-objcopy -O ihex $in $out
+
+rule elf2bin
+  command = arm-none-eabi-objcopy -O ihex $in $out
+
+rule hex2dfu
+  command = dfu-convert -i $in $out
+
+build bin/lgw_fw_usb.link_script.ld: preproc src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/TOOLCHAIN_GCC_ARM/STM32F401XE.ld
+build bin/startup_stm32f401xe.o: asmcompile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/TOOLCHAIN_GCC_ARM/startup_stm32f401xe.S
+
+build bin/analogin.o: cxxcompile src/mbed-dev/common/AnalogIn.cpp
+build bin/analogin_api.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/analogin_api.c
+build bin/analogout_api.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/analogout_api.c
+build bin/board.o: cxxcompile src/MAIN/board.cpp
+build bin/busin.o: cxxcompile src/mbed-dev/common/BusIn.cpp
+build bin/businout.o: cxxcompile src/mbed-dev/common/BusInOut.cpp
+build bin/busout.o: cxxcompile src/mbed-dev/common/BusOut.cpp
+build bin/callchain.o: cxxcompile src/mbed-dev/common/CallChain.cpp
+build bin/can.o: cxxcompile src/mbed-dev/common/CAN.cpp
+build bin/can_api.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/can_api.c
+build bin/cmdusb.o: cxxcompile src/MAIN/cmdUSB.cpp
+build bin/cmsis_nvic.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/cmsis_nvic.c
+build bin/entropy_hardware_poll.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/entropy_hardware_poll.c
+build bin/ethernet.o: cxxcompile src/mbed-dev/common/Ethernet.cpp
+build bin/filebase.o: cxxcompile src/mbed-dev/common/FileBase.cpp
+build bin/filelike.o: cxxcompile src/mbed-dev/common/FileLike.cpp
+build bin/filepath.o: cxxcompile src/mbed-dev/common/FilePath.cpp
+build bin/filesystemlike.o: cxxcompile src/mbed-dev/common/FileSystemLike.cpp
+build bin/gpio_api.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/gpio_api.c
+build bin/gpio_irq_api.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/gpio_irq_api.c
+build bin/hal_tick.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/hal_tick.c
+build bin/i2c.o: cxxcompile src/mbed-dev/common/I2C.cpp
+build bin/i2c_api.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/i2c_api.c
+build bin/i2cslave.o: cxxcompile src/mbed-dev/common/I2CSlave.cpp
+build bin/interruptin.o: cxxcompile src/mbed-dev/common/InterruptIn.cpp
+build bin/interruptmanager.o: cxxcompile src/mbed-dev/common/InterruptManager.cpp
+build bin/localfilesystem.o: cxxcompile src/mbed-dev/common/LocalFileSystem.cpp
+build bin/loragw_hal.o: cxxcompile src/SX1308HAL/src/loragw_hal.cpp
+build bin/loragw_reg.o: cxxcompile src/SX1308HAL/src/loragw_reg.cpp
+build bin/main.o: cxxcompile src/MAIN/main.cpp
+build bin/mbed_alloc_wrappers.o: cxxcompile src/mbed-dev/common/mbed_alloc_wrappers.cpp
+build bin/mbed_assert.o: compile src/mbed-dev/common/mbed_assert.c
+build bin/mbed_board.o: compile src/mbed-dev/common/mbed_board.c
+build bin/mbed_critical.o: compile src/mbed-dev/common/mbed_critical.c
+build bin/mbed_error.o: compile src/mbed-dev/common/mbed_error.c
+build bin/mbed_gpio.o: compile src/mbed-dev/common/mbed_gpio.c
+build bin/mbed_interface.o: compile src/mbed-dev/common/mbed_interface.c
+build bin/mbed_lp_ticker_api.o: compile src/mbed-dev/common/mbed_lp_ticker_api.c
+build bin/mbed_mem_trace.o: compile src/mbed-dev/common/mbed_mem_trace.c
+build bin/mbed_overrides.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/mbed_overrides.c
+build bin/mbed_pinmap_common.o: compile src/mbed-dev/common/mbed_pinmap_common.c
+build bin/mbed_rtc_time.o: cxxcompile src/mbed-dev/common/mbed_rtc_time.cpp
+build bin/mbed_semihost_api.o: compile src/mbed-dev/common/mbed_semihost_api.c
+build bin/mbed_ticker_api.o: compile src/mbed-dev/common/mbed_ticker_api.c
+build bin/mbed_us_ticker_api.o: compile src/mbed-dev/common/mbed_us_ticker_api.c
+build bin/mbed_wait_api.o: compile src/mbed-dev/common/mbed_wait_api.c
+build bin/peripheralpins.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/PeripheralPins.c
+build bin/pinmap.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/pinmap.c
+build bin/port_api.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/port_api.c
+build bin/pwmout_api.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/pwmout_api.c
+build bin/rawserial.o: cxxcompile src/mbed-dev/common/RawSerial.cpp
+build bin/retarget.o: cxxcompile src/mbed-dev/common/retarget.cpp
+build bin/rtc_api.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/rtc_api.c
+build bin/serial.o: cxxcompile src/mbed-dev/common/Serial.cpp
+build bin/serial_api.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
+build bin/serialbase.o: cxxcompile src/mbed-dev/common/SerialBase.cpp
+build bin/sleep.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/sleep.c
+build bin/spi.o: cxxcompile src/mbed-dev/common/SPI.cpp
+build bin/spi_api.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/spi_api.c
+build bin/spislave.o: cxxcompile src/mbed-dev/common/SPISlave.cpp
+build bin/stm32f4xx_hal.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal.c
+build bin/stm32f4xx_hal_adc.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_adc.c
+build bin/stm32f4xx_hal_adc_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_adc_ex.c
+build bin/stm32f4xx_hal_can.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_can.c
+build bin/stm32f4xx_hal_cec.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_cec.c
+build bin/stm32f4xx_hal_cortex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_cortex.c
+build bin/stm32f4xx_hal_crc.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_crc.c
+build bin/stm32f4xx_hal_cryp.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_cryp.c
+build bin/stm32f4xx_hal_cryp_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_cryp_ex.c
+build bin/stm32f4xx_hal_dac.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_dac.c
+build bin/stm32f4xx_hal_dac_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_dac_ex.c
+build bin/stm32f4xx_hal_dcmi.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_dcmi.c
+build bin/stm32f4xx_hal_dcmi_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_dcmi_ex.c
+build bin/stm32f4xx_hal_dfsdm.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_dfsdm.c
+build bin/stm32f4xx_hal_dma.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_dma.c
+build bin/stm32f4xx_hal_dma2d.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_dma2d.c
+build bin/stm32f4xx_hal_dma_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_dma_ex.c
+build bin/stm32f4xx_hal_dsi.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_dsi.c
+build bin/stm32f4xx_hal_eth.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_eth.c
+build bin/stm32f4xx_hal_flash.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_flash.c
+build bin/stm32f4xx_hal_flash_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_flash_ex.c
+build bin/stm32f4xx_hal_flash_ramfunc.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_flash_ramfunc.c
+build bin/stm32f4xx_hal_fmpi2c.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_fmpi2c.c
+build bin/stm32f4xx_hal_fmpi2c_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_fmpi2c_ex.c
+build bin/stm32f4xx_hal_gpio.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_gpio.c
+build bin/stm32f4xx_hal_hash.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_hash.c
+build bin/stm32f4xx_hal_hash_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_hash_ex.c
+build bin/stm32f4xx_hal_hcd.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_hcd.c
+build bin/stm32f4xx_hal_i2c.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_i2c.c
+build bin/stm32f4xx_hal_i2c_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_i2c_ex.c
+build bin/stm32f4xx_hal_i2s.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_i2s.c
+build bin/stm32f4xx_hal_i2s_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_i2s_ex.c
+build bin/stm32f4xx_hal_irda.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_irda.c
+build bin/stm32f4xx_hal_iwdg.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_iwdg.c
+build bin/stm32f4xx_hal_lptim.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_lptim.c
+build bin/stm32f4xx_hal_ltdc.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_ltdc.c
+build bin/stm32f4xx_hal_ltdc_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_ltdc_ex.c
+build bin/stm32f4xx_hal_msp_template.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_msp_template.c
+build bin/stm32f4xx_hal_nand.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_nand.c
+build bin/stm32f4xx_hal_nor.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_nor.c
+build bin/stm32f4xx_hal_pccard.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_pccard.c
+build bin/stm32f4xx_hal_pcd.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_pcd.c
+build bin/stm32f4xx_hal_pcd_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_pcd_ex.c
+build bin/stm32f4xx_hal_pwr.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_pwr.c
+build bin/stm32f4xx_hal_pwr_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_pwr_ex.c
+build bin/stm32f4xx_hal_qspi.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_qspi.c
+build bin/stm32f4xx_hal_rcc.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_rcc.c
+build bin/stm32f4xx_hal_rcc_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_rcc_ex.c
+build bin/stm32f4xx_hal_rng.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_rng.c
+build bin/stm32f4xx_hal_rtc.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_rtc.c
+build bin/stm32f4xx_hal_rtc_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_rtc_ex.c
+build bin/stm32f4xx_hal_sai.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_sai.c
+build bin/stm32f4xx_hal_sai_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_sai_ex.c
+build bin/stm32f4xx_hal_sd.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_sd.c
+build bin/stm32f4xx_hal_sdram.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_sdram.c
+build bin/stm32f4xx_hal_smartcard.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_smartcard.c
+build bin/stm32f4xx_hal_spdifrx.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_spdifrx.c
+build bin/stm32f4xx_hal_spi.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_spi.c
+build bin/stm32f4xx_hal_sram.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_sram.c
+build bin/stm32f4xx_hal_tim.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_tim.c
+build bin/stm32f4xx_hal_tim_ex.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_tim_ex.c
+build bin/stm32f4xx_hal_uart.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_uart.c
+build bin/stm32f4xx_hal_usart.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_usart.c
+build bin/stm32f4xx_hal_wwdg.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_wwdg.c
+build bin/stm32f4xx_it.o: cxxcompile src/usb_cdc/Src/stm32f4xx_it.cpp
+build bin/stm32f4xx_ll_fmc.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_ll_fmc.c
+build bin/stm32f4xx_ll_fsmc.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_ll_fsmc.c
+build bin/stm32f4xx_ll_sdmmc.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_ll_sdmmc.c
+build bin/stm32f4xx_ll_usb.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_ll_usb.c
+build bin/stream.o: cxxcompile src/mbed-dev/common/Stream.cpp
+build bin/sx1308.o: cxxcompile src/SX1308HAL/src/sx1308.cpp
+build bin/system_stm32f4xx.o: compile src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/system_stm32f4xx.c
+build bin/ticker.o: cxxcompile src/mbed-dev/common/Ticker.cpp
+build bin/timeout.o: cxxcompile src/mbed-dev/common/Timeout.cpp
+build bin/timer.o: cxxcompile src/mbed-dev/common/Timer.cpp
+build bin/timerevent.o: cxxcompile src/mbed-dev/common/TimerEvent.cpp
+build bin/us_ticker.o: compile src/mbed-dev/targets/hal/TARGET_STM/TARGET_STM32F4/us_ticker.c
+build bin/usb_device.o: cxxcompile src/usb_cdc/Src/usb_device.cpp
+build bin/usbd_cdc.o: cxxcompile src/usb_cdc/Src/usbd_cdc.cpp
+build bin/usbd_cdc_if.o: cxxcompile src/usb_cdc/Src/usbd_cdc_if.cpp
+build bin/usbd_conf.o: cxxcompile src/usb_cdc/Src/usbd_conf.cpp
+build bin/usbd_core.o: cxxcompile src/usb_cdc/Src/usbd_core.cpp
+build bin/usbd_ctlreq.o: cxxcompile src/usb_cdc/Src/usbd_ctlreq.cpp
+build bin/usbd_desc.o: cxxcompile src/usb_cdc/Src/usbd_desc.cpp
+build bin/usbd_ioreq.o: cxxcompile src/usb_cdc/Src/usbd_ioreq.cpp
+
+build bin/lgw_fw_usb.elf: link bin/lgw_fw_usb.link_script.ld bin/analogin.o bin/analogin_api.o bin/analogout_api.o bin/board.o bin/busin.o bin/businout.o bin/busout.o bin/callchain.o bin/can.o bin/can_api.o bin/cmdusb.o bin/cmsis_nvic.o bin/entropy_hardware_poll.o bin/ethernet.o bin/filebase.o bin/filelike.o bin/filepath.o bin/filesystemlike.o bin/gpio_api.o bin/gpio_irq_api.o bin/hal_tick.o bin/i2c.o bin/i2c_api.o bin/i2cslave.o bin/interruptin.o bin/interruptmanager.o bin/localfilesystem.o bin/loragw_hal.o bin/loragw_reg.o bin/main.o bin/mbed_alloc_wrappers.o bin/mbed_assert.o bin/mbed_board.o bin/mbed_critical.o bin/mbed_error.o bin/mbed_gpio.o bin/mbed_interface.o bin/mbed_lp_ticker_api.o bin/mbed_mem_trace.o bin/mbed_overrides.o bin/mbed_pinmap_common.o bin/mbed_rtc_time.o bin/mbed_semihost_api.o bin/mbed_ticker_api.o bin/mbed_us_ticker_api.o bin/mbed_wait_api.o bin/peripheralpins.o bin/pinmap.o bin/port_api.o bin/pwmout_api.o bin/rawserial.o bin/retarget.o bin/rtc_api.o bin/serial.o bin/serial_api.o bin/serialbase.o bin/sleep.o bin/spi.o bin/spi_api.o bin/spislave.o bin/startup_stm32f401xe.o bin/stm32f4xx_hal.o bin/stm32f4xx_hal_adc.o bin/stm32f4xx_hal_adc_ex.o bin/stm32f4xx_hal_can.o bin/stm32f4xx_hal_cec.o bin/stm32f4xx_hal_cortex.o bin/stm32f4xx_hal_crc.o bin/stm32f4xx_hal_cryp.o bin/stm32f4xx_hal_cryp_ex.o bin/stm32f4xx_hal_dac.o bin/stm32f4xx_hal_dac_ex.o bin/stm32f4xx_hal_dcmi.o bin/stm32f4xx_hal_dcmi_ex.o bin/stm32f4xx_hal_dfsdm.o bin/stm32f4xx_hal_dma.o bin/stm32f4xx_hal_dma2d.o bin/stm32f4xx_hal_dma_ex.o bin/stm32f4xx_hal_dsi.o bin/stm32f4xx_hal_eth.o bin/stm32f4xx_hal_flash.o bin/stm32f4xx_hal_flash_ex.o bin/stm32f4xx_hal_flash_ramfunc.o bin/stm32f4xx_hal_fmpi2c.o bin/stm32f4xx_hal_fmpi2c_ex.o bin/stm32f4xx_hal_gpio.o bin/stm32f4xx_hal_hash.o bin/stm32f4xx_hal_hash_ex.o bin/stm32f4xx_hal_hcd.o bin/stm32f4xx_hal_i2c.o bin/stm32f4xx_hal_i2c_ex.o bin/stm32f4xx_hal_i2s.o bin/stm32f4xx_hal_i2s_ex.o bin/stm32f4xx_hal_irda.o bin/stm32f4xx_hal_iwdg.o bin/stm32f4xx_hal_lptim.o bin/stm32f4xx_hal_ltdc.o bin/stm32f4xx_hal_ltdc_ex.o bin/stm32f4xx_hal_msp_template.o bin/stm32f4xx_hal_nand.o bin/stm32f4xx_hal_nor.o bin/stm32f4xx_hal_pccard.o bin/stm32f4xx_hal_pcd.o bin/stm32f4xx_hal_pcd_ex.o bin/stm32f4xx_hal_pwr.o bin/stm32f4xx_hal_pwr_ex.o bin/stm32f4xx_hal_qspi.o bin/stm32f4xx_hal_rcc.o bin/stm32f4xx_hal_rcc_ex.o bin/stm32f4xx_hal_rng.o bin/stm32f4xx_hal_rtc.o bin/stm32f4xx_hal_rtc_ex.o bin/stm32f4xx_hal_sai.o bin/stm32f4xx_hal_sai_ex.o bin/stm32f4xx_hal_sd.o bin/stm32f4xx_hal_sdram.o bin/stm32f4xx_hal_smartcard.o bin/stm32f4xx_hal_spdifrx.o bin/stm32f4xx_hal_spi.o bin/stm32f4xx_hal_sram.o bin/stm32f4xx_hal_tim.o bin/stm32f4xx_hal_tim_ex.o bin/stm32f4xx_hal_uart.o bin/stm32f4xx_hal_usart.o bin/stm32f4xx_hal_wwdg.o bin/stm32f4xx_it.o bin/stm32f4xx_ll_fmc.o bin/stm32f4xx_ll_fsmc.o bin/stm32f4xx_ll_sdmmc.o bin/stm32f4xx_ll_usb.o bin/stream.o bin/sx1308.o bin/system_stm32f4xx.o bin/ticker.o bin/timeout.o bin/timer.o bin/timerevent.o bin/us_ticker.o bin/usb_device.o bin/usbd_cdc.o bin/usbd_cdc_if.o bin/usbd_conf.o bin/usbd_core.o bin/usbd_ctlreq.o bin/usbd_desc.o bin/usbd_ioreq.o
+
+build bin/lgw_fw_usb.hex: elf2hex bin/lgw_fw_usb.elf
+
+build bin/lgw_fw_usb.bin: elf2bin bin/lgw_fw_usb.elf
+
+build bin/lgw_fw_usb.dfu: hex2dfu bin/lgw_fw_usb.hex
+
+default bin/lgw_fw_usb.dfu

--- a/src/MAIN/board.h
+++ b/src/MAIN/board.h
@@ -10,7 +10,7 @@
 #define BOARD_H
 
 #include "mbed.h"
-#include "SX1308.h"
+#include "sx1308.h"
 
 //#define USE_UART 1
 

--- a/src/MAIN/cmdUSB.cpp
+++ b/src/MAIN/cmdUSB.cpp
@@ -8,7 +8,7 @@
 
 */
 
-#include "CmdUSB.h"
+#include "cmdUSB.h"
 #include "usb_device.h"
 #include "usbd_cdc_if.h"
 #include "loragw_hal.h"

--- a/src/MAIN/cmdUSB.h
+++ b/src/MAIN/cmdUSB.h
@@ -11,7 +11,7 @@
 #define USBMANAGER_H
 
 #include "mbed.h"
-#include "SX1308.h"
+#include "sx1308.h"
 
 #define ATOMICTX 900
 #define ATOMICRX 600

--- a/src/MAIN/main.cpp
+++ b/src/MAIN/main.cpp
@@ -12,7 +12,7 @@
 #include "usb_device.h"
 #include "usbd_cdc_if.h"
 #include "string.h"
-#include "CmdUSB.h"
+#include "cmdUSB.h"
 #include "board.h"
 
 #include "loragw_reg.h"

--- a/src/SX1308HAL/src/loragw_hal.cpp
+++ b/src/SX1308HAL/src/loragw_hal.cpp
@@ -112,21 +112,23 @@ static uint64_t fsk_sync_word = 0xC194C1; /* default FSK sync word (ALIGNED RIGH
 static bool lorawan_public = true;
 
 static struct lgw_tx_gain_lut_s txgain_lut = {
-    .size = 2,
-    .lut[0] = {
-        .dig_gain = 0,
-        .pa_gain = 2,
-        .dac_gain = 3,
-        .mix_gain = 10,
-        .rf_power = 14
+    {
+        /* .lut[0] */ {
+            /* .dig_gain */ 0,
+            /* .pa_gain */ 2,
+            /* .dac_gain */ 3,
+            /* .mix_gain */ 10,
+            /* .rf_power */ 14
+        },
+        /* .lut[1] */ {
+            /* .dig_gain */ 0,
+            /* .pa_gain */ 3,
+            /* .dac_gain */ 3,
+            /* .mix_gain */ 14,
+            /* .rf_power */ 27
+        }
     },
-    .lut[1] = {
-        .dig_gain = 0,
-        .pa_gain = 3,
-        .dac_gain = 3,
-        .mix_gain = 14,
-        .rf_power = 27
-    }
+    /* .size */ 2,
 };
 
 /* TX I/Q imbalance coefficients for mixer gain = 8 to 15 */

--- a/src/SX1308HAL/src/loragw_reg.cpp
+++ b/src/SX1308HAL/src/loragw_reg.cpp
@@ -8,7 +8,7 @@
 
 
 */
-#include "SX1308.h"
+#include "sx1308.h"
 #include "loragw_reg.h"
 #include "board.h"
 

--- a/src/SX1308HAL/src/sx1308.cpp
+++ b/src/SX1308HAL/src/sx1308.cpp
@@ -7,7 +7,7 @@
   (C)2017 Semtech
 */
 
-#include "SX1308.h"
+#include "sx1308.h"
 #include "mbed.h"
 #include "board.h"
 #include "loragw_hal.h"

--- a/src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/TOOLCHAIN_GCC_ARM/STM32F401XE.ld
+++ b/src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/TOOLCHAIN_GCC_ARM/STM32F401XE.ld
@@ -1,0 +1,153 @@
+/* Linker script to configure memory regions. */
+MEMORY
+{ 
+  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 512K
+  RAM (rwx)  : ORIGIN = 0x20000194, LENGTH = 96k - 0x194
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ * 
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   _estack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .text :
+    {
+        KEEP(*(.isr_vector))
+        *(.text*)
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        KEEP(*(.eh_frame*))
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
+
+    __etext = .;
+    _sidata = .;
+
+    .data : AT (__etext)
+    {
+        __data_start__ = .;
+        _sdata = .;
+        *(vtable)
+        *(.data*)
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        KEEP(*(.jcr*))
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+        _edata = .;
+
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        _sbss = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+        _ebss = .;
+    } > RAM
+
+    .heap (COPY):
+    {
+        __end__ = .;
+        end = __end__;
+        *(.heap*)
+        __HeapLimit = .;
+    } > RAM
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > RAM
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    _estack = __StackTop;
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/TOOLCHAIN_GCC_ARM/startup_stm32f401xe.S
+++ b/src/mbed-dev/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/TOOLCHAIN_GCC_ARM/startup_stm32f401xe.S
@@ -1,0 +1,455 @@
+/**
+  ******************************************************************************
+  * @file      startup_stm32f401xe.s
+  * @author    MCD Application Team
+  * @version   V2.3.0
+  * @date      02-March-2015
+  * @brief     STM32F401xExx Devices vector table for Atollic TrueSTUDIO toolchain.
+  *            This module performs:
+  *                - Set the initial SP
+  *                - Set the initial PC == Reset_Handler,
+  *                - Set the vector table entries with the exceptions ISR address
+  *                - Branches to main in the C library (which eventually
+  *                  calls main()).
+  *            After Reset the Cortex-M4 processor is in Thread mode,
+  *            priority is Privileged, and the Stack is set to Main.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+  .syntax unified
+  .cpu cortex-m4
+  .fpu softvfp
+  .thumb
+
+.global  g_pfnVectors
+.global  Default_Handler
+
+/* start address for the initialization values of the .data section.
+defined in linker script */
+.word  _sidata
+/* start address for the .data section. defined in linker script */
+.word  _sdata
+/* end address for the .data section. defined in linker script */
+.word  _edata
+/* start address for the .bss section. defined in linker script */
+.word  _sbss
+/* end address for the .bss section. defined in linker script */
+.word  _ebss
+/* stack used for SystemInit_ExtMemCtl; always internal RAM used */
+
+/**
+ * @brief  This is the code that gets called when the processor first
+ *          starts execution following a reset event. Only the absolutely
+ *          necessary set is performed, after which the application
+ *          supplied main() routine is called.
+ * @param  None
+ * @retval : None
+*/
+
+    .section  .text.Reset_Handler
+  .weak  Reset_Handler
+  .type  Reset_Handler, %function
+Reset_Handler:
+  ldr   sp, =_estack    		 /* set stack pointer */
+
+/* Copy the data segment initializers from flash to SRAM */
+  movs  r1, #0
+  b  LoopCopyDataInit
+
+CopyDataInit:
+  ldr  r3, =_sidata
+  ldr  r3, [r3, r1]
+  str  r3, [r0, r1]
+  adds  r1, r1, #4
+
+LoopCopyDataInit:
+  ldr  r0, =_sdata
+  ldr  r3, =_edata
+  adds  r2, r0, r1
+  cmp  r2, r3
+  bcc  CopyDataInit
+  ldr  r2, =_sbss
+  b  LoopFillZerobss
+/* Zero fill the bss segment. */
+FillZerobss:
+  movs  r3, #0
+  str  r3, [r2], #4
+
+LoopFillZerobss:
+  ldr  r3, = _ebss
+  cmp  r2, r3
+  bcc  FillZerobss
+
+/* Call the clock system intitialization function.*/
+  bl  SystemInit
+/* Call static constructors */
+  //bl __libc_init_array
+/* Call the application's entry point.*/
+  //bl  main
+  // Calling the crt0 'cold-start' entry point. There __libc_init_array is called
+  // and when existing hardware_init_hook() and software_init_hook() before
+  // starting main(). software_init_hook() is available and has to be called due
+  // to initializsation when using rtos.
+  bl _start
+  bx  lr
+.size  Reset_Handler, .-Reset_Handler
+
+/**
+ * @brief  This is the code that gets called when the processor receives an
+ *         unexpected interrupt.  This simply enters an infinite loop, preserving
+ *         the system state for examination by a debugger.
+ * @param  None
+ * @retval None
+*/
+    .section  .text.Default_Handler,"ax",%progbits
+Default_Handler:
+Infinite_Loop:
+  b  Infinite_Loop
+  .size  Default_Handler, .-Default_Handler
+/******************************************************************************
+*
+* The minimal vector table for a Cortex M3. Note that the proper constructs
+* must be placed on this to ensure that it ends up at physical address
+* 0x0000.0000.
+*
+*******************************************************************************/
+   .section  .isr_vector,"a",%progbits
+  .type  g_pfnVectors, %object
+  .size  g_pfnVectors, .-g_pfnVectors
+
+g_pfnVectors:
+  .word  _estack
+  .word  Reset_Handler
+  .word  NMI_Handler
+  .word  HardFault_Handler
+  .word  MemManage_Handler
+  .word  BusFault_Handler
+  .word  UsageFault_Handler
+  .word  0
+  .word  0
+  .word  0
+  .word  0
+  .word  SVC_Handler
+  .word  DebugMon_Handler
+  .word  0
+  .word  PendSV_Handler
+  .word  SysTick_Handler
+
+  /* External Interrupts */
+  .word     WWDG_IRQHandler                   /* Window WatchDog              */
+  .word     PVD_IRQHandler                    /* PVD through EXTI Line detection */
+  .word     TAMP_STAMP_IRQHandler             /* Tamper and TimeStamps through the EXTI line */
+  .word     RTC_WKUP_IRQHandler               /* RTC Wakeup through the EXTI line */
+  .word     FLASH_IRQHandler                  /* FLASH                        */
+  .word     RCC_IRQHandler                    /* RCC                          */
+  .word     EXTI0_IRQHandler                  /* EXTI Line0                   */
+  .word     EXTI1_IRQHandler                  /* EXTI Line1                   */
+  .word     EXTI2_IRQHandler                  /* EXTI Line2                   */
+  .word     EXTI3_IRQHandler                  /* EXTI Line3                   */
+  .word     EXTI4_IRQHandler                  /* EXTI Line4                   */
+  .word     DMA1_Stream0_IRQHandler           /* DMA1 Stream 0                */
+  .word     DMA1_Stream1_IRQHandler           /* DMA1 Stream 1                */
+  .word     DMA1_Stream2_IRQHandler           /* DMA1 Stream 2                */
+  .word     DMA1_Stream3_IRQHandler           /* DMA1 Stream 3                */
+  .word     DMA1_Stream4_IRQHandler           /* DMA1 Stream 4                */
+  .word     DMA1_Stream5_IRQHandler           /* DMA1 Stream 5                */
+  .word     DMA1_Stream6_IRQHandler           /* DMA1 Stream 6                */
+  .word     ADC_IRQHandler                    /* ADC1, ADC2 and ADC3s         */
+  .word     0               				  /* Reserved                      */
+  .word     0              					  /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     EXTI9_5_IRQHandler                /* External Line[9:5]s          */
+  .word     TIM1_BRK_TIM9_IRQHandler          /* TIM1 Break and TIM9          */
+  .word     TIM1_UP_TIM10_IRQHandler          /* TIM1 Update and TIM10        */
+  .word     TIM1_TRG_COM_TIM11_IRQHandler     /* TIM1 Trigger and Commutation and TIM11 */
+  .word     TIM1_CC_IRQHandler                /* TIM1 Capture Compare         */
+  .word     TIM2_IRQHandler                   /* TIM2                         */
+  .word     TIM3_IRQHandler                   /* TIM3                         */
+  .word     TIM4_IRQHandler                   /* TIM4                         */
+  .word     I2C1_EV_IRQHandler                /* I2C1 Event                   */
+  .word     I2C1_ER_IRQHandler                /* I2C1 Error                   */
+  .word     I2C2_EV_IRQHandler                /* I2C2 Event                   */
+  .word     I2C2_ER_IRQHandler                /* I2C2 Error                   */
+  .word     SPI1_IRQHandler                   /* SPI1                         */
+  .word     SPI2_IRQHandler                   /* SPI2                         */
+  .word     USART1_IRQHandler                 /* USART1                       */
+  .word     USART2_IRQHandler                 /* USART2                       */
+  .word     0               				  /* Reserved                       */
+  .word     EXTI15_10_IRQHandler              /* External Line[15:10]s        */
+  .word     RTC_Alarm_IRQHandler              /* RTC Alarm (A and B) through EXTI Line */
+  .word     OTG_FS_WKUP_IRQHandler            /* USB OTG FS Wakeup through EXTI line */
+  .word     0                                 /* Reserved     				  */
+  .word     0                                 /* Reserved       			  */
+  .word     0                                 /* Reserved 					  */
+  .word     0                                 /* Reserved                     */
+  .word     DMA1_Stream7_IRQHandler           /* DMA1 Stream7                 */
+  .word     0                                 /* Reserved                     */
+  .word     SDIO_IRQHandler                   /* SDIO                         */
+  .word     TIM5_IRQHandler                   /* TIM5                         */
+  .word     SPI3_IRQHandler                   /* SPI3                         */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     DMA2_Stream0_IRQHandler           /* DMA2 Stream 0                */
+  .word     DMA2_Stream1_IRQHandler           /* DMA2 Stream 1                */
+  .word     DMA2_Stream2_IRQHandler           /* DMA2 Stream 2                */
+  .word     DMA2_Stream3_IRQHandler           /* DMA2 Stream 3                */
+  .word     DMA2_Stream4_IRQHandler           /* DMA2 Stream 4                */
+  .word     0                    			  /* Reserved                     */
+  .word     0              					  /* Reserved                     */
+  .word     0              					  /* Reserved                     */
+  .word     0             					  /* Reserved                     */
+  .word     0              					  /* Reserved                     */
+  .word     0              					  /* Reserved                     */
+  .word     OTG_FS_IRQHandler                 /* USB OTG FS                   */
+  .word     DMA2_Stream5_IRQHandler           /* DMA2 Stream 5                */
+  .word     DMA2_Stream6_IRQHandler           /* DMA2 Stream 6                */
+  .word     DMA2_Stream7_IRQHandler           /* DMA2 Stream 7                */
+  .word     USART6_IRQHandler                 /* USART6                       */
+  .word     I2C3_EV_IRQHandler                /* I2C3 event                   */
+  .word     I2C3_ER_IRQHandler                /* I2C3 error                   */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     FPU_IRQHandler                    /* FPU                          */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     SPI4_IRQHandler                   /* SPI4                         */
+
+/*******************************************************************************
+*
+* Provide weak aliases for each Exception handler to the Default_Handler.
+* As they are weak aliases, any function with the same name will override
+* this definition.
+*
+*******************************************************************************/
+   .weak      NMI_Handler
+   .thumb_set NMI_Handler,Default_Handler
+
+   .weak      HardFault_Handler
+   .thumb_set HardFault_Handler,Default_Handler
+
+   .weak      MemManage_Handler
+   .thumb_set MemManage_Handler,Default_Handler
+
+   .weak      BusFault_Handler
+   .thumb_set BusFault_Handler,Default_Handler
+
+   .weak      UsageFault_Handler
+   .thumb_set UsageFault_Handler,Default_Handler
+
+   .weak      SVC_Handler
+   .thumb_set SVC_Handler,Default_Handler
+
+   .weak      DebugMon_Handler
+   .thumb_set DebugMon_Handler,Default_Handler
+
+   .weak      PendSV_Handler
+   .thumb_set PendSV_Handler,Default_Handler
+
+   .weak      SysTick_Handler
+   .thumb_set SysTick_Handler,Default_Handler
+
+   .weak      WWDG_IRQHandler
+   .thumb_set WWDG_IRQHandler,Default_Handler
+
+   .weak      PVD_IRQHandler
+   .thumb_set PVD_IRQHandler,Default_Handler
+
+   .weak      TAMP_STAMP_IRQHandler
+   .thumb_set TAMP_STAMP_IRQHandler,Default_Handler
+
+   .weak      RTC_WKUP_IRQHandler
+   .thumb_set RTC_WKUP_IRQHandler,Default_Handler
+
+   .weak      FLASH_IRQHandler
+   .thumb_set FLASH_IRQHandler,Default_Handler
+
+   .weak      RCC_IRQHandler
+   .thumb_set RCC_IRQHandler,Default_Handler
+
+   .weak      EXTI0_IRQHandler
+   .thumb_set EXTI0_IRQHandler,Default_Handler
+
+   .weak      EXTI1_IRQHandler
+   .thumb_set EXTI1_IRQHandler,Default_Handler
+
+   .weak      EXTI2_IRQHandler
+   .thumb_set EXTI2_IRQHandler,Default_Handler
+
+   .weak      EXTI3_IRQHandler
+   .thumb_set EXTI3_IRQHandler,Default_Handler
+
+   .weak      EXTI4_IRQHandler
+   .thumb_set EXTI4_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream0_IRQHandler
+   .thumb_set DMA1_Stream0_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream1_IRQHandler
+   .thumb_set DMA1_Stream1_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream2_IRQHandler
+   .thumb_set DMA1_Stream2_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream3_IRQHandler
+   .thumb_set DMA1_Stream3_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream4_IRQHandler
+   .thumb_set DMA1_Stream4_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream5_IRQHandler
+   .thumb_set DMA1_Stream5_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream6_IRQHandler
+   .thumb_set DMA1_Stream6_IRQHandler,Default_Handler
+
+   .weak      ADC_IRQHandler
+   .thumb_set ADC_IRQHandler,Default_Handler
+
+   .weak      EXTI9_5_IRQHandler
+   .thumb_set EXTI9_5_IRQHandler,Default_Handler
+
+   .weak      TIM1_BRK_TIM9_IRQHandler
+   .thumb_set TIM1_BRK_TIM9_IRQHandler,Default_Handler
+
+   .weak      TIM1_UP_TIM10_IRQHandler
+   .thumb_set TIM1_UP_TIM10_IRQHandler,Default_Handler
+
+   .weak      TIM1_TRG_COM_TIM11_IRQHandler
+   .thumb_set TIM1_TRG_COM_TIM11_IRQHandler,Default_Handler
+
+   .weak      TIM1_CC_IRQHandler
+   .thumb_set TIM1_CC_IRQHandler,Default_Handler
+
+   .weak      TIM2_IRQHandler
+   .thumb_set TIM2_IRQHandler,Default_Handler
+
+   .weak      TIM3_IRQHandler
+   .thumb_set TIM3_IRQHandler,Default_Handler
+
+   .weak      TIM4_IRQHandler
+   .thumb_set TIM4_IRQHandler,Default_Handler
+
+   .weak      I2C1_EV_IRQHandler
+   .thumb_set I2C1_EV_IRQHandler,Default_Handler
+
+   .weak      I2C1_ER_IRQHandler
+   .thumb_set I2C1_ER_IRQHandler,Default_Handler
+
+   .weak      I2C2_EV_IRQHandler
+   .thumb_set I2C2_EV_IRQHandler,Default_Handler
+
+   .weak      I2C2_ER_IRQHandler
+   .thumb_set I2C2_ER_IRQHandler,Default_Handler
+
+   .weak      SPI1_IRQHandler
+   .thumb_set SPI1_IRQHandler,Default_Handler
+
+   .weak      SPI2_IRQHandler
+   .thumb_set SPI2_IRQHandler,Default_Handler
+
+   .weak      USART1_IRQHandler
+   .thumb_set USART1_IRQHandler,Default_Handler
+
+   .weak      USART2_IRQHandler
+   .thumb_set USART2_IRQHandler,Default_Handler
+
+   .weak      EXTI15_10_IRQHandler
+   .thumb_set EXTI15_10_IRQHandler,Default_Handler
+
+   .weak      RTC_Alarm_IRQHandler
+   .thumb_set RTC_Alarm_IRQHandler,Default_Handler
+
+   .weak      OTG_FS_WKUP_IRQHandler
+   .thumb_set OTG_FS_WKUP_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream7_IRQHandler
+   .thumb_set DMA1_Stream7_IRQHandler,Default_Handler
+
+   .weak      SDIO_IRQHandler
+   .thumb_set SDIO_IRQHandler,Default_Handler
+
+   .weak      TIM5_IRQHandler
+   .thumb_set TIM5_IRQHandler,Default_Handler
+
+   .weak      SPI3_IRQHandler
+   .thumb_set SPI3_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream0_IRQHandler
+   .thumb_set DMA2_Stream0_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream1_IRQHandler
+   .thumb_set DMA2_Stream1_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream2_IRQHandler
+   .thumb_set DMA2_Stream2_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream3_IRQHandler
+   .thumb_set DMA2_Stream3_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream4_IRQHandler
+   .thumb_set DMA2_Stream4_IRQHandler,Default_Handler
+
+   .weak      OTG_FS_IRQHandler
+   .thumb_set OTG_FS_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream5_IRQHandler
+   .thumb_set DMA2_Stream5_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream6_IRQHandler
+   .thumb_set DMA2_Stream6_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream7_IRQHandler
+   .thumb_set DMA2_Stream7_IRQHandler,Default_Handler
+
+   .weak      USART6_IRQHandler
+   .thumb_set USART6_IRQHandler,Default_Handler
+
+   .weak      I2C3_EV_IRQHandler
+   .thumb_set I2C3_EV_IRQHandler,Default_Handler
+
+   .weak      I2C3_ER_IRQHandler
+   .thumb_set I2C3_ER_IRQHandler,Default_Handler
+
+   .weak      FPU_IRQHandler
+   .thumb_set FPU_IRQHandler,Default_Handler
+
+   .weak      SPI4_IRQHandler
+   .thumb_set SPI4_IRQHandler,Default_Handler
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/usb_cdc/Src/usbd_conf.cpp
+++ b/src/usb_cdc/Src/usbd_conf.cpp
@@ -57,7 +57,7 @@ void SystemClock_Config(void);
 *******************************************************************************/
 /* MSP Init */
 
-#include "CmdUSB.h"
+#include "cmdUSB.h"
 
 void HAL_PCD_MspInit(PCD_HandleTypeDef* pcdHandle)
 {


### PR DESCRIPTION
Chose ninja build-system (instead of GNU Make or CMake), because of its simplistic syntax. Being easy to learn and understand. Expecting one to edit it accordingly for their use.

Compiles and works in USB mode.

Edited the sources slightly:
1. Some includes were case-insensitive, causing issues.
2. One particular C++ struct was using non-standard syntax, corrected that too.
3. Included GCC specific bootstrap code from: https://github.com/ARMmbed/mbed-os at 21dd7008a1540c02150f1b87c12294301db979bb

PS: Project is inconsistent on Line-endings (Both, unix & dos). May I suggest a look at: https://editorconfig.org/