### PR TITLE
Device skips first message after USB Reset. Fix.

### DIFF
--- a/src/usb_cdc/Src/usbd_cdc_if.cpp
+++ b/src/usb_cdc/Src/usbd_cdc_if.cpp
@@ -59,8 +59,8 @@
 /* USER CODE BEGIN PRIVATE_DEFINES */
 /* Define size for the receive and transmit buffer over CDC */
 /* It's up to user to redefine and/or remove those define */
-#define APP_RX_DATA_SIZE  8200
-#define APP_TX_DATA_SIZE  8200
+//#define APP_RX_DATA_SIZE  8200
+//#define APP_TX_DATA_SIZE  8200
 /* USER CODE END PRIVATE_DEFINES */
 /**
   * @}
@@ -82,10 +82,13 @@
 /* Create buffer for reception and transmission           */
 /* It's up to user to redefine and/or remove those define */
 /* Received Data over USB are stored in this buffer       */
-uint8_t UserRxBufferFS[APP_RX_DATA_SIZE];
+//uint8_t UserRxBufferFS[APP_RX_DATA_SIZE];
 
 /* Send Data over USB CDC are stored in this buffer       */
-uint8_t UserTxBufferFS[APP_TX_DATA_SIZE];
+//uint8_t UserTxBufferFS[APP_TX_DATA_SIZE];
+
+/* Use CmdManager Buffers instead of commented out placeholders above */
+#include <cmdUSB.h>
 
 /* USER CODE BEGIN PRIVATE_VARIABLES */
 /* USER CODE END PRIVATE_VARIABLES */
@@ -138,9 +141,12 @@ USBD_CDC_ItfTypeDef USBD_Interface_fops_FS =
 static int8_t CDC_Init_FS(void)
 { 
   /* USER CODE BEGIN 3 */ 
-  /* Set Application Buffers */
-  USBD_CDC_SetTxBuffer(&hUsbDeviceFS, UserTxBufferFS, 0);
-  USBD_CDC_SetRxBuffer(&hUsbDeviceFS, UserRxBufferFS);
+  /* Set Application Buffers to CmdManager */
+  USBD_CDC_SetTxBuffer(&hUsbDeviceFS, (uint8_t*) &CmdManager.BufToHost[0], sizeof CmdManager.BufToHost);
+  USBD_CDC_SetRxBuffer(&hUsbDeviceFS, (uint8_t*) &CmdManager.BufFromHostChunk[0]);
+  /* then reset main() loop. */
+  CmdManager.BufFromHostChunk[0] = 0x00;
+  CmdManager.count = 0;
   return (USBD_OK);
   /* USER CODE END 3 */ 
 }
@@ -301,6 +307,3 @@ uint8_t CDC_Transmit_FS(uint8_t* Buf, uint16_t Len)
   */ 
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
-
-
-


### PR DESCRIPTION
Notes
======
In normal operation, firmware calls `CmdManager.ReceiveCmd()`, which
does preparations, relevant one being `xfer_buff` pointer being set,
it's where we'll expect USB OUT data. Then wait in an infinite loop
`while(count>0){}`, until interrupt handler lets it out via `count=0`.

But if a *USB Reset* happens when device was already powered on, interrupt
handler changes `xfer_buff` in the middle of `CmdManager.ReceiveCmd()`,
the main flow of execution is still where it left off, at that loop,
but with initial preperations being now untrue.
Until the `CmdManager.ReceiveCmd()` is run again. This is why 2nd message
from host is responded to, while silent on 1st one.

USB Reset happens when Host OS Boots up, you could even pass-through
USB to a OS emulated in qemu, to reproduce without rebooting real host.

Fix
1. After *USB Reset*, cause the main loop continue a new iteration.
   (All we gotta do is `CmdManager.BufFromHost[0] = 0; CmdManager.count = 0;`.
   That will cause `CmdManager.ReceiveCmd()` to exit the loop. And the
   `CmdManager.DecodeCmd()` return `0 # CMD_ERROR` thus going straight
   to a new `CmdManager.ReceiveCmd()`.
2. Since UserRxBufferFS is actually just a remnant of code reuse,
   and EP1 IN/OUT is only used by CDC Bulk, I went ahead and replaced it.

Relevant events happen during OUT EP0 SET CONFIGURATION Control Request.

Workaround
======
Changing values manually via gdb (the workaroud below) allows the message
to be parsed on the first try instead of the second:

``` c
p (USB_OTG_EPTypeDef[2]) *hpcd_USB_OTG_FS.OUT_ep
set ((USB_OTG_EPTypeDef[2]) *hpcd_USB_OTG_FS.OUT_ep)[1].xfer_count = 0
set ((USB_OTG_EPTypeDef[2]) *hpcd_USB_OTG_FS.OUT_ep)[1].xfer_len = 64
set ((USB_OTG_EPTypeDef[2]) *hpcd_USB_OTG_FS.OUT_ep)[1].xfer_buff = &CmdManager.BufFromHostChunk
p (USB_OTG_EPTypeDef[2]) *hpcd_USB_OTG_FS.OUT_ep
continue
```

Re-enumerate USB without reboot
======
ioctl("/dev/bus/usb/<BUS#>/<DEV#>", USBDEVFS_RESET)